### PR TITLE
Update workflow to generate test coverage statistics

### DIFF
--- a/.github/workflows/astro-testing.yml
+++ b/.github/workflows/astro-testing.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python application
+name: Astro Testing
 
 on:
   push:
@@ -33,9 +33,10 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
+        flake8 . --count  --max-complexity=10 --max-line-length=127 --statistics
+    - name: Run pytest under coverage
       run: |
-        pushd src/tests/
-        pytest
-        popd
+        coverage run -m pytest
+    - name: Generate coverage report
+      run: |
+        coverage report -m

--- a/.github/workflows/astro-testing.yml
+++ b/.github/workflows/astro-testing.yml
@@ -33,7 +33,7 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count  --max-complexity=10 --max-line-length=127 --statistics
+        flake8 . --count  --exclude src/tests/test_api_responses.py --max-complexity=10 --max-line-length=127 --statistics
     - name: Run pytest under coverage
       run: |
         coverage run -m pytest

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,6 +2,7 @@ cachetools==5.5.0
 certifi==2024.8.30
 charset-normalizer==3.3.2
 click==8.1.7
+coverage==7.6.1
 flake8==7.1.1
 google-api-core==2.20.0
 google-api-python-client==2.146.0

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -6,6 +6,8 @@ import pandas as pd
 from unittest.mock import MagicMock
 from src.log import Logger
 
+import src.tests.test_api_responses as test_responses
+
 
 @pytest.fixture(scope='class')
 def comment_dataframe():
@@ -20,12 +22,7 @@ def comment_dataframe():
 
 @pytest.fixture(scope='class')
 def api_comment_response():
-    response = {}
-
-    with open('test_comment_api_response.json', 'r') as f:
-        response = json.load(f)
-
-    return response
+    return json.loads(test_responses.test_comment_api_response)
 
 
 @pytest.fixture(scope='class')

--- a/src/tests/test_api_responses.py
+++ b/src/tests/test_api_responses.py
@@ -1,3 +1,10 @@
+"""
+This file contains example YouTube Data API responses for use
+in testing.
+"""
+
+
+test_comment_api_response = """
 {
     "kind": "youtube#commentThreadListResponse",
     "etag": "Leymzj7IilCkKdGveEdfycOes08",
@@ -69,3 +76,6 @@
         }
     ]
 }
+"""
+
+test_empty_api_response = "{}"


### PR DESCRIPTION
Update workflow to generate test coverage statistics using `coverage` with `pytest`.

This work also included:
- Moving test json api strings to a python file in `src/tests` so that they can be imported
- Updating the `requirements.txt` file to include the `coverage` tool
- Renamed the workflow to 'Astro Testing' and the file itself to `astro-testing.yml`