### PR TITLE
Remove randomness from `AstroDB.create_unique_table_name`

### DIFF
--- a/src/astro_db.py
+++ b/src/astro_db.py
@@ -2,10 +2,10 @@
 Class for managing comment/video database.
 """
 import sqlite3
-import string
 
 import pandas as pd
 from src.data_collection.yt_data_api import YouTubeDataAPI
+
 
 class AstroDB:
     conn = None

--- a/src/astro_db.py
+++ b/src/astro_db.py
@@ -2,8 +2,6 @@
 Class for managing comment/video database.
 """
 import sqlite3
-import string
-import random
 
 import pandas as pd
 
@@ -22,36 +20,65 @@ class AstroDB:
     def get_db_conn(self):
         return self.conn
 
-    def comment_table_exists(self, table_name: str) -> bool:
+    def get_next_table_name(self, last_table_name: str) -> str:
         """
-        Check the 'Videos' table for an entry containing the provided
-        table name in the 'comment_table' column.
+        Roll the provided string forward by 'incrementing' the
+        letters. See below for some example transitions:
+
+        AAA -> BAA
+        BAA -> CAA
+        ...
+        ZAA -> ABA
+        ABA -> BBA
         """
+        # 'roll' the name forward
+        def next_char(c: chr) -> chr:
+            return chr(ord(c) + 1)
 
-        query = f"SELECT * FROM Videos WHERE comment_table='{table_name}'"
-        self.cursor.execute(query)
-        table_exists = self.cursor.fetchone()
+        new_name = ''
+        rolled = 0
 
-        return bool(table_exists)
+        for i in range(len(last_table_name)):
+            if last_table_name[i] != 'Z':
+                new_name += next_char(last_table_name[i])
+                new_name += last_table_name[i+1:len(last_table_name)]
+                break
+            else:
+                rolled += 1
+                new_name += 'A'
+                if rolled == len(last_table_name):
+                    raise StopIteration("Limit exceeded for number of comment tables in database")
+
+        return new_name
 
     def create_unique_table_name(self) -> str:
         """
-        Create a random table name from uppercase letters.
+        This function effectively implements a string odometer. The
+        name returned will be a 3 character string consisting of capital
+        letters. Each successive call will 'roll forward' the last-created
+        comment table name.
+
+        Once the odometer reaches its limit of ZZZ, the next call will
+        result in an exception. This should only happen after the creation of
+        26^3 (17576) tables, which is a limit I'm comfortable with since I doubt
+        we'll be tracking over one hundred YouTube videos, let alone over 17k.
         """
-        attempts = 3  # 3 attempts to generate unique string
-        id_string = ''
+        # Get most recent comment table name by grabbing latest entry in the Videos table
+        self.cursor.execute("SELECT comment_table FROM Videos ORDER BY id DESC LIMIT 1")
 
-        # Generate random names until we get one that doesn't exist
-        while attempts > 0:
-            id_string = ''.join(random.choices(string.ascii_uppercase, k=12))
+        last_table_name = self.cursor.fetchone()
+        if not last_table_name:  # this is the first comment table we're creating
+            return 'AAA'
+        else:
+            last_table_name = last_table_name[0]
 
-            if self.comment_table_exists(id_string):
-                self.logger.warning('Comment table name collision!')
-                attempts -= 1
-            else:
-                return id_string
+        self.logger.debug('last table name: {}'.format(last_table_name))
 
-        return ''
+        new_name = self.get_next_table_name(last_table_name)
+
+        self.logger.debug('unique table name: {}'.format(new_name))
+
+        return new_name
 
     def create_videos_table(self):
         """

--- a/src/data_collection/yt_data_api.py
+++ b/src/data_collection/yt_data_api.py
@@ -23,8 +23,8 @@ class YouTubeDataAPI:
     @staticmethod
     def valid_video_id(video_id: str) -> bool:
         valid_tokens = (string.ascii_uppercase +
-                       string.ascii_lowercase +
-                       string.digits + '-' + '_')
+                        string.ascii_lowercase +
+                        string.digits + '-' + '_')
 
         if video_id:
             for token in video_id:

--- a/src/data_collection/yt_data_api.py
+++ b/src/data_collection/yt_data_api.py
@@ -4,6 +4,7 @@ Functions for gathering data from YouTube.
 
 import pandas as pd
 import traceback
+import string
 
 from src.data_collection.data_structures import VideoData
 from googleapiclient.discovery import build
@@ -18,6 +19,23 @@ class YouTubeDataAPI:
         self.logger = logger.get_logger()
         self.api_key = api_key
         self.youtube = build('youtube', 'v3', developerKey=self.api_key)
+
+    @staticmethod
+    def valid_video_id(video_id: str) -> bool:
+        valid_tokens = (string.ascii_uppercase +
+                       string.ascii_lowercase +
+                       string.digits + '-' + '_')
+
+        if video_id:
+            for token in video_id:
+                if token not in valid_tokens:
+                    return False
+
+            # all tokens are valid
+            return True
+
+        # null video_id
+        return False
 
     def parse_comment_api_response(self, response) -> pd.DataFrame:
         """

--- a/src/tests/astro_mocks.py
+++ b/src/tests/astro_mocks.py
@@ -15,8 +15,8 @@ class MockSqlite3Cursor:
         else:
             return None
 
-    def execute(self, query: str):
-        return self.return_value
+    def execute(self, *args):
+        return
 
 
 class MockSqlite3Connection:

--- a/src/tests/astro_mocks.py
+++ b/src/tests/astro_mocks.py
@@ -1,0 +1,32 @@
+"""
+This file will contain all mock classes used for testing.
+"""
+
+
+class MockSqlite3Cursor:
+    return_value = None
+
+    def __init__(self, return_value):
+        self.return_value = return_value
+
+    def fetchone(self):
+        if self.return_value:
+            return (self.return_value,)
+        else:
+            return None
+
+    def execute(self, query: str):
+        return self.return_value
+
+
+class MockSqlite3Connection:
+    return_value = None
+
+    def set_return_value(self, return_value):
+        self.return_value = return_value
+
+    def cursor(self):
+        return MockSqlite3Cursor(self.return_value)
+
+    def commit(self):
+        return

--- a/src/tests/test_astro_db.py
+++ b/src/tests/test_astro_db.py
@@ -107,7 +107,6 @@ class TestAstroDB:
             name = astro_db.create_unique_table_name()
             assert name == table_names[1]
 
-
     @pytest.mark.parametrize('video_data', test_video_data)
     def test_get_comment_table_for(self, astro_db, video_data):
         # verify that AstroDB finds the comment table

--- a/src/tests/test_astro_db.py
+++ b/src/tests/test_astro_db.py
@@ -99,8 +99,8 @@ class TestAstroDB:
         cursor = conn.cursor()
 
         bad_input = not video_data or \
-                    not video_data.channel_id or \
-                    not YouTubeDataAPI.valid_video_id(video_data.video_id)
+            not video_data.channel_id or \
+            not YouTubeDataAPI.valid_video_id(video_data.video_id)
 
         if bad_input:  # expect an exception
             with pytest.raises(ValueError) as exception:


### PR DESCRIPTION
This change will remove the randomness from `AstroDB.create_unique_name`. The new method for generating unique names involves the manipulation of a 3 character string consisting of capital letters.

The first table name will be named `AAA`. For each additional table, the name will be 'rolled forward' such that:
```
AAA -> BAA -> CAA -> DAA -> ... -> ZAA -> ABA -> BBA -> ... -> YZZ -> ZZZ
```

This will provide `26^3` (17576) possible names. It is unlikely for this limit to present a problem, since that would imply we have over 17k YouTube videos' worth of data in our database.

Additional work in this change:
- Removed unused AstroDB.comment_table_exists method and associated test
- Modified the existing test for AstroDB.create_unique_table_name to account for new functionality
    - Added 2 mock classes in the new `tests/astro_mocks.py file`
        - MockSqlite3Connection
        - MockSqlite3Cursor
    - Added a fixture mock_sqlite3_connect to utilize the above mock classes to mock the database
        - I should now have full control over the database with this fixture