### PR TITLE
Add badge icons for build status and test coverage to README (#44)

### DIFF
--- a/.github/workflows/astro-testing.yml
+++ b/.github/workflows/astro-testing.yml
@@ -1,7 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-
-name: Astro Testing
+name: CI build
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![CI build](https://github.com/AustinCullar/Astro/actions/workflows/astro-testing.yml/badge.svg) ![Test coverage](https://img.shields.io/badge/Code%20Coverage-83%25-success?style=flat)
+![CI build](https://github.com/AustinCullar/Astro/actions/workflows/astro-testing.yml/badge.svg) ![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)
 
 # Astro
 Automated data collection from YouTube.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![CI build](https://github.com/AustinCullar/Astro/actions/workflows/astro-testing.yml/badge.svg) ![Test coverage](https://img.shields.io/badge/Code%20Coverage-83%25-success?style=flat)
+
 # Astro
 Automated data collection from YouTube.
 


### PR DESCRIPTION
Modified workflow file to rename the job to `CI build`, since this will likely affect how the badge shows up in the README.

The README was modified to include the badge icon at the top of the file.