### PR TITLE
Add support for comment paging (#41)

### DIFF
--- a/src/astro_db.py
+++ b/src/astro_db.py
@@ -92,6 +92,9 @@ class AstroDB:
             channel_title TEXT, \
             channel_id TEXT, \
             video_id TEXT, \
+            views INT, \
+            likes INT, \
+            comment_count INT, \
             comment_table TEXT)")
 
         self.conn.commit()
@@ -113,11 +116,15 @@ class AstroDB:
         table_name = self.create_unique_table_name()
         assert table_name, "Failed to create unique comment table in database"
 
-        query = f"INSERT INTO Videos (channel_title, channel_id, video_id, comment_table) \
+        query = f"INSERT INTO Videos \
+                (channel_title, channel_id, video_id, views, likes, comment_count, comment_table) \
                 VALUES ( \
                 '{video_data.channel_title}', \
                 '{video_data.channel_id}', \
                 '{video_data.video_id}', \
+                '{video_data.like_count}', \
+                '{video_data.view_count}', \
+                '{video_data.comment_count}', \
                 '{table_name}')"
 
         self.cursor.execute(query)

--- a/src/data_collection/yt_data_api.py
+++ b/src/data_collection/yt_data_api.py
@@ -37,13 +37,17 @@ class YouTubeDataAPI:
         # null video_id
         return False
 
-    def parse_comment_api_response(self, response) -> pd.DataFrame:
+    def parse_comment_api_response(self, response, comment_dataframe) -> pd.DataFrame:
         """
         Parse API response for comment query. This will grab all comments and their replies,
         storing the resulting data in a dataframe.
         """
-        df_index = 0
-        df = pd.DataFrame(columns=['comment', 'user', 'date'])
+        if comment_dataframe is not None and not comment_dataframe.empty:  # we're appending data to the dataframe
+            df_index = len(comment_dataframe.index)-1  # last index in dataframe
+            df = comment_dataframe
+        else:  # we're creating a new dataframe
+            df_index = 0
+            df = pd.DataFrame(columns=['comment', 'user', 'date'])
 
         for item in response['items']:
             has_replies = 0 != item['snippet']['totalReplyCount']
@@ -79,20 +83,29 @@ class YouTubeDataAPI:
         * Publish date
 
         """
-        request = self.youtube.commentThreads().list(
-            part="snippet,replies",
-            videoId=video_data.video_id,
-            textFormat="plainText")
 
         comment_dataframe = None
+        page_token = ''
+        unfetched_comments = True
 
-        try:
-            response = request.execute()
-            comment_dataframe = self.parse_comment_api_response(response)
+        while unfetched_comments:
+            request = self.youtube.commentThreads().list(
+                part='snippet,replies',
+                videoId=video_data.video_id,
+                pageToken=page_token,
+                textFormat='plainText')
 
-        except Exception as e:
-            self.logger.error(str(e))
-            self.logger.error(traceback.format_exc())
+            try:
+                response = request.execute()
+                comment_dataframe = self.parse_comment_api_response(response, comment_dataframe)
+                if 'nextPageToken' in response:  # there are more comments to fetch
+                    page_token = response['nextPageToken']
+                else:
+                    unfetched_comments = False
+
+            except Exception as e:
+                self.logger.error(str(e))
+                self.logger.error(traceback.format_exc())
 
         return comment_dataframe
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -5,8 +5,7 @@ import googleapiclient
 import pandas as pd
 from unittest.mock import MagicMock
 from src.log import Logger
-
-import test_api_responses as api_responses
+import src.tests.test_api_responses as api_responses
 
 
 @pytest.fixture(scope='class')

--- a/src/tests/test_astro_db.py
+++ b/src/tests/test_astro_db.py
@@ -121,7 +121,10 @@ class TestAstroDB:
             assert video_table_data[1] == video_data.channel_title
             assert video_table_data[2] == video_data.channel_id
             assert video_table_data[3] == video_data.video_id
-            assert video_table_data[4] == comment_table_name
+            assert video_table_data[4] == video_data.like_count
+            assert video_table_data[5] == video_data.view_count
+            assert video_table_data[6] == video_data.comment_count
+            assert video_table_data[7] == comment_table_name
 
             self.created_comment_tables.append(comment_table_name)
 

--- a/src/tests/test_yt_data_api.py
+++ b/src/tests/test_yt_data_api.py
@@ -84,12 +84,12 @@ class TestYouTubeDataAPI:
         youtube = YouTubeDataAPI(logger, 'test_apikey')
 
         video_data = VideoData(
-                video_id = 'video_id',
-                channel_id = 'FvlvKP-khoFMOeyBzmXuaazd',
-                channel_title = 'channel_title',
-                view_count = 123,
-                like_count = 123,
-                comment_count = 123)
+                video_id='video_id',
+                channel_id='FvlvKP-khoFMOeyBzmXuaazd',
+                channel_title='channel_title',
+                view_count=123,
+                like_count=123,
+                comment_count=123)
 
         api_comment_response = parametrize_api_comment_response(
             api_comment_response,
@@ -99,7 +99,6 @@ class TestYouTubeDataAPI:
             authorDisplayName=authorDisplayName,
             replyTextDisplay=replyTextDisplay,
             replyAuthorDisplayName=replyAuthorDisplayName)
-
 
         df = youtube.get_comments(video_data)
 

--- a/src/tests/test_yt_data_api.py
+++ b/src/tests/test_yt_data_api.py
@@ -83,21 +83,23 @@ class TestYouTubeDataAPI:
 
         youtube = YouTubeDataAPI(logger, 'test_apikey')
 
+        video_data = VideoData(
+                video_id = 'video_id',
+                channel_id = 'FvlvKP-khoFMOeyBzmXuaazd',
+                channel_title = 'channel_title',
+                view_count = 123,
+                like_count = 123,
+                comment_count = 123)
+
         api_comment_response = parametrize_api_comment_response(
             api_comment_response,
+            videoId=video_data.video_id,
             textDisplay=textDisplay,
             publishedAt=publishedAt,
             authorDisplayName=authorDisplayName,
             replyTextDisplay=replyTextDisplay,
             replyAuthorDisplayName=replyAuthorDisplayName)
 
-        video_data = VideoData()
-        video_data.video_id = 'video_id'
-        video_data.channel_id = 'FvlvKP-khoFMOeyBzmXuaazd'
-        video_data.channel_title = 'channel_title'
-        video_data.view_count = 123
-        video_data.like_count = 123
-        video_data.comment_count = 123
 
         df = youtube.get_comments(video_data)
 

--- a/src/tests/test_yt_data_api.py
+++ b/src/tests/test_yt_data_api.py
@@ -150,6 +150,6 @@ class TestYouTubeDataAPI:
 
         assert video_data.channel_id == channelId
         assert video_data.channel_title == channelTitle
-        assert video_data.like_count == likeCount
-        assert video_data.view_count == viewCount
-        assert video_data.comment_count == commentCount
+        assert video_data.like_count == int(likeCount)
+        assert video_data.view_count == int(viewCount)
+        assert video_data.comment_count == int(commentCount)


### PR DESCRIPTION
When pulling large amounts of comments from a video, the Data API will sometimes require an additional API request that utilizes the `nextPageToken` provided in the previous response.

This change adds support for detecting this field and makes additional requests to pull all comments.