### PR TITLE
Add support for appending comment data to database on successive Astro runs

### DIFF
--- a/src/astro_db.py
+++ b/src/astro_db.py
@@ -123,8 +123,8 @@ class AstroDB:
                 '{video_data.channel_title}', \
                 '{video_data.channel_id}', \
                 '{video_data.video_id}', \
-                '{video_data.like_count}', \
                 '{video_data.view_count}', \
+                '{video_data.like_count}', \
                 '{video_data.comment_count}', \
                 '{table_name}')"
 

--- a/src/data_collection/data_structures.py
+++ b/src/data_collection/data_structures.py
@@ -23,6 +23,6 @@ class VideoData:
         self.video_id = video_id
         self.channel_id = channel_id
         self.channel_title = channel_title
-        self.view_count = 0
-        self.like_count = 0
-        self.comment_count = 0
+        self.view_count = view_count
+        self.like_count = like_count
+        self.comment_count = comment_count

--- a/src/data_collection/yt_data_api.py
+++ b/src/data_collection/yt_data_api.py
@@ -84,7 +84,6 @@ class YouTubeDataAPI:
         * Username
         * Comment text
         * Publish date
-
         """
 
         comment_dataframe = None
@@ -94,15 +93,19 @@ class YouTubeDataAPI:
 
         while unfetched_comments:
             # The API limits comment requests to 100 records
-            max_results = min(100, comment_count)
-            comment_count -= max_results
+            max_comments = min(100, comment_count)
+
+            self.logger.debug('collecting {} comments'.format(max_comments))
 
             request = self.youtube.commentThreads().list(
                 part='snippet,replies',
                 videoId=video_data.video_id,
                 pageToken=page_token,
-                maxResults=max_results,
+                maxResults=max_comments,
                 textFormat='plainText')
+
+            comment_count -= max_comments
+            unfetched_comments = True if comment_count > 0 else False
 
             try:
                 response = request.execute()

--- a/src/tests/test_astro_db.py
+++ b/src/tests/test_astro_db.py
@@ -207,11 +207,11 @@ class TestAstroDB:
             comment_data = cursor.fetchall()
 
             # verify that the data in the table matches that in the dataframe
-            index = 1
+            index = 0
             for row in comment_data:
-                assert row[0] == index
-                assert row[1] == comment_dataframe.loc[index]['comment']
-                assert row[2] == comment_dataframe.loc[index]['user']
+                assert row[0] == index+1
+                assert row[1] == comment_dataframe.loc[index]['user']
+                assert row[2] == comment_dataframe.loc[index]['comment']
                 assert row[3] == comment_dataframe.loc[index]['date']
 
                 index += 1

--- a/src/tests/test_astro_db.py
+++ b/src/tests/test_astro_db.py
@@ -121,8 +121,8 @@ class TestAstroDB:
             assert video_table_data[1] == video_data.channel_title
             assert video_table_data[2] == video_data.channel_id
             assert video_table_data[3] == video_data.video_id
-            assert video_table_data[4] == video_data.like_count
-            assert video_table_data[5] == video_data.view_count
+            assert video_table_data[4] == video_data.view_count
+            assert video_table_data[5] == video_data.like_count
             assert video_table_data[6] == video_data.comment_count
             assert video_table_data[7] == comment_table_name
 
@@ -215,3 +215,20 @@ class TestAstroDB:
                 assert row[3] == comment_dataframe.loc[index]['date']
 
                 index += 1
+
+    @pytest.mark.parametrize('video_data', [video_data for video_data in test_video_data if video_data])
+    def test_get_video_data(self, astro_db, video_data):
+        conn = astro_db.get_db_conn()
+        cursor = conn.cursor()
+
+        if YouTubeDataAPI.valid_video_id(video_data.video_id):
+            cursor.execute(f"SELECT * from Videos WHERE video_id='{video_data.video_id}'")
+            db_entry = cursor.fetchone()
+
+            assert db_entry
+            assert db_entry[1] == video_data.channel_title
+            assert db_entry[2] == video_data.channel_id
+            assert db_entry[3] == video_data.video_id
+            assert db_entry[4] == video_data.view_count
+            assert db_entry[5] == video_data.like_count
+            assert db_entry[6] == video_data.comment_count

--- a/src/tests/test_astro_db.py
+++ b/src/tests/test_astro_db.py
@@ -207,7 +207,7 @@ class TestAstroDB:
             comment_data = cursor.fetchall()
 
             # verify that the data in the table matches that in the dataframe
-            index = 0
+            index = 1
             for row in comment_data:
                 assert row[0] == index
                 assert row[1] == comment_dataframe.loc[index]['comment']


### PR DESCRIPTION
Now, upon attempting to run `astro` against the same video URL, the following message will be displayed if there are no new comments:
```
(astro) $ python astro.py 'https://www.youtube.com/watch?v=Ygm_885doX8' -l info --api-key <key> --db-file astro.db
...
INFO:astro.py:main: No new comments to fetch for provided video
```

This bypasses the comment API call as well. Regardless of whether comments are pulled, the video metadata (likes and views) will be updated in the `Videos` table. It might be nice to track the changes to this data over time, but I'll leave that for a separate issue.