### PR TITLE
Add `FileHandler` for logging to file, new argument for logging API JSON responses to file

### DIFF
--- a/src/astro.py
+++ b/src/astro.py
@@ -38,11 +38,14 @@ def parse_args(astro_theme):
     parser = argparse.ArgumentParser(description=description,
                                      formatter_class=ArgumentDefaultsRichHelpFormatter)
 
-    parser.add_argument("youtube_url", type=str, help="youtube video URL")
-    parser.add_argument("-l", "--log", type=str, choices=['debug', 'info', 'warn', 'error'],
+    parser.add_argument('youtube_url', type=str, help='youtube video URL')
+    parser.add_argument('-l', '--log', type=str, choices=['debug', 'info', 'warn', 'error'],
                         help='Set the logging level', default='info')
-    parser.add_argument("--api-key", type=str, help="YouTube Data API key")
-    parser.add_argument("--db-file", type=str, help="database filename", default='astro.db')
+    parser.add_argument('--api-key', type=str, help='YouTube Data API key')
+    parser.add_argument('--db-file', type=str, help='database filename', default='astro.db')
+    parser.add_argument('--log-file', type=str, help='log output to specified file', default='astro_log.txt')
+    parser.add_argument('-j', '--log-json', type=bool, help='log json API responses',
+                        default=False, action=argparse.BooleanOptionalAction)
     args = parser.parse_args()
 
     return args
@@ -63,19 +66,19 @@ def main():
     log_level = args.log if args.log else os.getenv("LOG_LEVEL")
     api_key = args.api_key if args.api_key else os.getenv("API_KEY")
     db_file = args.db_file if args.db_file else os.getenv("DB_FILE")
+    log_file = args.log_file if args.log_file else os.getenv("LOG_FILE")
+    log_json = args.log_json if args.log_json else os.getenv("LOG_JSON")
 
     # set up logging
     logging.setLoggerClass(AstroLogger)
     logger = logging.getLogger(__name__)
-    logger.astro_config(log_level, astro_theme)
-
-    logger.info('Collecting video data...')
+    logger.astro_config(log_level, astro_theme, log_file=log_file)
 
     # collect metadata for provided video
-    youtube = YouTubeDataAPI(logger, api_key)
+    youtube = YouTubeDataAPI(logger, api_key, log_json)
     video_data = youtube.get_video_metadata(video_id)
 
-    logger.print_object(video_data, title="Video data")
+    logger.print_video_data(video_data)
 
     # check local database for existing data on provided video
     db = AstroDB(logger, db_file)

--- a/src/data_collection/yt_data_api.py
+++ b/src/data_collection/yt_data_api.py
@@ -124,7 +124,7 @@ class YouTubeDataAPI:
                     response = request.execute()
                     if self.log_json:
                         with self.logger.log_file_only():
-                            self.logger.debug(json.dumps(response, indent=4))
+                            self.logger.info(json.dumps(response, indent=4))
 
                     comment_dataframe, comments_added = self.parse_comment_api_response(response, comment_dataframe)
                     if 'nextPageToken' in response:  # there are more comments to fetch
@@ -164,7 +164,7 @@ class YouTubeDataAPI:
             response = request.execute()
             if self.log_json:
                 with self.logger.log_file_only():
-                    self.logger.debug(json.dumps(response, indent=4))
+                    self.logger.info(json.dumps(response, indent=4))
 
             video_data = response['items'][0]['snippet']
             video_stats = response['items'][0]['statistics']

--- a/src/data_collection/yt_data_api.py
+++ b/src/data_collection/yt_data_api.py
@@ -4,6 +4,7 @@ Functions for gathering data from YouTube.
 import pandas as pd
 import traceback
 import string
+import json
 
 from src.data_collection.data_structures import VideoData
 from googleapiclient.discovery import build
@@ -13,10 +14,12 @@ class YouTubeDataAPI:
     logger = None
     api_key = None
     youtube = None
+    log_json = False
 
-    def __init__(self, logger, api_key):
+    def __init__(self, logger, api_key, log_json=False):
         self.logger = logger
         self.api_key = api_key
+        self.log_json = log_json
         self.youtube = build('youtube', 'v3', developerKey=self.api_key)
 
     @staticmethod
@@ -119,6 +122,10 @@ class YouTubeDataAPI:
 
                 try:
                     response = request.execute()
+                    if self.log_json:
+                        with self.logger.log_file_only():
+                            self.logger.debug(json.dumps(response, indent=4))
+
                     comment_dataframe, comments_added = self.parse_comment_api_response(response, comment_dataframe)
                     if 'nextPageToken' in response:  # there are more comments to fetch
                         page_token = response['nextPageToken']
@@ -155,6 +162,10 @@ class YouTubeDataAPI:
 
         try:
             response = request.execute()
+            if self.log_json:
+                with self.logger.log_file_only():
+                    self.logger.debug(json.dumps(response, indent=4))
+
             video_data = response['items'][0]['snippet']
             video_stats = response['items'][0]['statistics']
 

--- a/src/tests/test_log.py
+++ b/src/tests/test_log.py
@@ -28,10 +28,9 @@ class TestLogging:
 
             assert str(exception.value) == "Invalid logger level specified: {}".format(level)
 
-    @pytest.mark.parametrize('obj', test_video_data)
-    @pytest.mark.parametrize('title', ['title1', 'title-2', 'title_3'])
-    def test_print_object(self, logger, obj, title):
-        logger.print_object(obj, title=title)
+    @pytest.mark.parametrize('video_data', test_video_data)
+    def test_print_video_data(self, logger, video_data):
+        logger.print_video_data(video_data)
 
     @pytest.mark.parametrize('title', ['title1', 'title-2', 'title_3'])
     def test_print_dataframe(self, logger, comment_dataframe, title):


### PR DESCRIPTION
Two new arguments are added here:
- `--log-json | -j`: log JSON responses from API to the log file only
- `--log-file`: specify name/location of log file (`./astro_log.txt` by default)

Other changes:
- Add contextmanager method to AstroLogger() to facilitate logging only to file
    - this is used to capture json responses, since these are very noisy
- AstroLogger.print_object() has been replaced with print_video_data()
    - Trying to move away from rich tables, as these are not printed to log file
- logging tests modified to account for log method changes