### PR TITLE
Rework comment collection

### DIFF
--- a/src/astro.py
+++ b/src/astro.py
@@ -15,20 +15,6 @@ from theme import AstroTheme
 from rich_argparse import ArgumentDefaultsRichHelpFormatter
 
 
-def extract_video_id_from_url(url: str) -> str:
-    """
-    Grab the video ID from the provided URL. The ID will come after
-    the substring 'v=' in the URL, so I just split the string on that
-    substring and return the latter half.
-    """
-
-    video_id = url.split('v=')[1]
-    if not YouTubeDataAPI.valid_video_id(video_id):
-        raise ValueError('Invalid video URL provided')
-
-    return video_id
-
-
 def parse_args(astro_theme):
     """
     Argument parsing logic. Returns the arguments parsed from the CLI
@@ -57,7 +43,6 @@ def main():
 
     # parse arguments
     args = parse_args(astro_theme)
-    video_id = extract_video_id_from_url(args.youtube_url)
 
     # load environment variables
     load_dotenv()
@@ -76,7 +61,7 @@ def main():
 
     # collect metadata for provided video
     youtube = YouTubeDataAPI(logger, api_key, log_json)
-    video_data = youtube.get_video_metadata(video_id)
+    video_data = youtube.get_video_metadata(args.youtube_url)
 
     logger.print_video_data(video_data)
 

--- a/src/astro.py
+++ b/src/astro.py
@@ -80,21 +80,8 @@ def main():
 
     logger.print_video_data(video_data)
 
-    # check local database for existing data on provided video
+    # connect to local database
     db = AstroDB(logger, db_file)
-    db_video_data = db.get_video_data(video_data.video_id)
-
-    if db_video_data:  # we already have a database table for this video
-        # determine how many new comments we need to fetch
-        video_data.comment_count -= db_video_data.comment_count
-
-        if 0 >= video_data.comment_count:
-            logger.info('Comment data is current; no new comments to collect')
-            # if comments have been deleted, video_data.comment_count may be a negative value
-            # explicitly set comment_count to 0 here to avoid adding negative value to db
-            video_data.comment_count = 0
-            db.update_video_data(video_data)
-            return
 
     if video_data.comments_disabled:
         logger.info('Comments have been disabled for the provided video')
@@ -121,7 +108,6 @@ def main():
                 'of comments')
 
     logger.print_dataframe(comments_df, title='Comment data preview')
-
     logger.info('Data collection complete.')
 
 

--- a/src/log.py
+++ b/src/log.py
@@ -137,12 +137,12 @@ class AstroLogger(logging.Logger):
 
         # add dataframe rows
         for row in df.values:
-            comment_len = len(row[0])
+            comment_len = len(row[1])
 
             # limit comment preview to `max_comment_len` characters
-            row[0] = row[0][:max_comment_len]
+            row[1] = row[1][:max_comment_len]
             if comment_len > max_comment_len:
-                row[0] += '...'
+                row[1] += '...'
 
             table.add_row(*row)
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -10,13 +10,27 @@ from src.log import AstroLogger
 from src.theme import AstroTheme
 
 
-@pytest.fixture(scope='class')
+@pytest.fixture(scope='function')
 def comment_dataframe():
-    df = pd.DataFrame(columns=['comment', 'user', 'date'])
+    df = pd.DataFrame(columns=['comment_id', 'comment', 'user', 'date', 'visible'])
 
-    df.loc[0] = ['hello there', '@user1', '2022-10-23T19:05:89Z']
-    df.loc[1] = ['this is terrible', '@user2', '2023-10-23T20:05:89Z']
-    df.loc[2] = ['this is awesome!', '@user3', '2021-8-23T20:11:90Z']
+    df.loc[0] = ['UgyMLcxXS1Id2SaBuJd4AaABAg',
+                 'hello there',
+                 '@user1',
+                 '2022-10-23T19:05:89Z',
+                 1]
+
+    df.loc[1] = ['UgwJuUmFZtOgkjrCrlp4AaABAg',
+                 'this is terrible',
+                 '@user2',
+                 '2023-10-23T20:05:89Z',
+                 1]
+
+    df.loc[2] = ['UgwJuUmFZtOgkjrCrlp4AaABAg.A9Y4JkqJXpPA9Y4Z0_I_BA',
+                 'this is awesome!',
+                 '@user3',
+                 '2021-8-23T20:11:90Z',
+                 1]
 
     return df
 

--- a/src/tests/test_astro_db.py
+++ b/src/tests/test_astro_db.py
@@ -54,6 +54,39 @@ def database_fault(mock_sqlite3_connect, logger):
 class TestAstroDB:
     created_comment_tables = []
 
+    def __get_comment_table_for_video_data(self, conn, video_data):
+        cursor = conn.cursor()
+
+        cursor.execute(f"SELECT comment_table FROM Videos WHERE video_id='{video_data.video_id}'")
+        comment_table = cursor.fetchone()[0]
+
+        return comment_table
+
+    def __get_table_row_count(self, conn, table_name):
+        cursor = conn.cursor()
+
+        cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+        row_count = cursor.fetchone()[0]
+
+        return row_count
+
+    def __insert_dataframe_exception(self, astro_db, comment_dataframe, video_data) -> bool:
+        bad_input = not video_data or \
+                    not YouTubeDataAPI.valid_video_id(video_data.video_id)
+
+        if not bad_input:
+            return False
+
+        # expect an exception
+        with pytest.raises(ValueError) as exception:
+            astro_db.insert_comment_dataframe(video_data, comment_dataframe)
+            if not video_data:
+                assert str(exception.value) == 'NULL video data'
+            elif not YouTubeDataAPI.valid_video_id(video_data.video_id):
+                assert str(exception.value) == 'Invalid video id'
+
+        return True
+
     def test_create_videos_table(self, astro_db):
         astro_db.create_videos_table()
 
@@ -76,14 +109,14 @@ class TestAstroDB:
 
         if bad_input:  # expect an exception
             with pytest.raises(ValueError) as exception:
-                comment_table_name = astro_db.create_comment_table_for_video(video_data)
+                comment_table_name = astro_db._AstroDB__create_comment_table_for_video(video_data)
                 if not video_data:
                     assert str(exception.value) == 'NULL video data'
                 elif not video_data.channel_id or not video_data.video_id:
                     assert str(exception.value) == 'Invalid video data'
         else:
             # create entry in Videos table along with a new comment table for that video
-            comment_table_name = astro_db.create_comment_table_for_video(video_data)
+            comment_table_name = astro_db._AstroDB__create_comment_table_for_video(video_data)
 
             # verify creation of entry in Videos and the new comment table
             cursor.execute(f"SELECT * FROM Videos WHERE video_id='{video_data.video_id}'")
@@ -114,10 +147,10 @@ class TestAstroDB:
 
         if table_names[0] == 'ZZZ':
             with pytest.raises(StopIteration) as exception:
-                name = astro_db.create_unique_table_name()
+                name = astro_db._AstroDB__create_unique_table_name()
                 assert str(exception.value) == 'Limit exceeded for number of comment tables in database'
         else:
-            name = astro_db.create_unique_table_name()
+            name = astro_db._AstroDB__create_unique_table_name()
             assert name == table_names[1]
 
     @pytest.mark.parametrize('fail_database_query', [True, False])
@@ -131,7 +164,7 @@ class TestAstroDB:
         normal_run = YouTubeDataAPI.valid_video_id(video_id) and not fail_database_query
 
         # verify that AstroDB finds the comment table
-        table_name = astro_db.get_comment_table_for(video_id)
+        table_name = astro_db._AstroDB__get_comment_table_for(video_id)
 
         assert table_name if normal_run else not table_name
 
@@ -148,17 +181,7 @@ class TestAstroDB:
 
     @pytest.mark.parametrize('video_data', test_video_data)
     def test_insert_comment_dataframe(self, astro_db, video_data, comment_dataframe):
-        bad_input = not video_data or \
-                    not YouTubeDataAPI.valid_video_id(video_data.video_id)
-
-        if bad_input:  # expect an exception
-            with pytest.raises(ValueError) as exception:
-                astro_db.insert_comment_dataframe(video_data, comment_dataframe)
-                if not video_data:
-                    assert str(exception.value) == 'NULL video data'
-                elif not YouTubeDataAPI.valid_video_id(video_data.video_id):
-                    assert str(exception.value) == 'Invalid video id'
-        else:  # insert dataframe into database, verify table contents
+        if not self.__insert_dataframe_exception(astro_db, comment_dataframe, video_data):
             astro_db.insert_comment_dataframe(video_data, comment_dataframe)
 
             conn = astro_db.get_db_conn()
@@ -183,9 +206,11 @@ class TestAstroDB:
             index = 0
             for row in comment_data:
                 assert row[0] == index+1
-                assert row[1] == comment_dataframe.loc[index]['user']
+                assert row[1] == comment_dataframe.loc[index]['comment_id']
                 assert row[2] == comment_dataframe.loc[index]['comment']
-                assert row[3] == comment_dataframe.loc[index]['date']
+                assert row[3] == comment_dataframe.loc[index]['user']
+                assert row[4] == comment_dataframe.loc[index]['date']
+                assert row[5] == comment_dataframe.loc[index]['visible']
 
                 index += 1
 
@@ -205,3 +230,83 @@ class TestAstroDB:
             assert db_entry[4] == video_data.view_count
             assert db_entry[5] == video_data.like_count
             assert db_entry[6] == video_data.comment_count
+            assert db_entry[7] == video_data.filtered_comment_count
+
+    @pytest.mark.parametrize('video_data', [test_video_data[0]])
+    def test_new_comment_detection(self, astro_db, comment_dataframe, video_data):
+        conn = astro_db.get_db_conn()
+        cursor = conn.cursor()
+
+        # insert dataframe
+        astro_db.insert_comment_dataframe(video_data, comment_dataframe)
+
+        # get newly created comment table
+        comment_table = self.__get_comment_table_for_video_data(conn, video_data)
+        orig_comment_count = self.__get_table_row_count(conn, comment_table)
+
+        # append 2 new dummy comments to dataframe
+        comment_data1 = ['id1', 'comment1', 'test_user', '10.25.2024', 1]
+        comment_data2 = ['id2', 'comment2', 'test_user', '10.26.2024', 1]
+        index = len(comment_dataframe.index)
+        comment_dataframe.loc[index] = comment_data1
+        comment_dataframe.loc[index+1] = comment_data2
+
+        # insert dataframe
+        astro_db.insert_comment_dataframe(video_data, comment_dataframe)
+        new_comment_count = self.__get_table_row_count(conn, comment_table)
+
+        # verify new comments were added
+        cursor.execute(f"SELECT comment_id FROM {comment_table} WHERE user='test_user'")
+        comment_ids = cursor.fetchall()
+
+        assert len(comment_ids) == 2  # make sure we added 2 new comments
+        assert comment_ids[0][0] == comment_data1[0]
+        assert comment_ids[1][0] == comment_data2[0]
+        assert new_comment_count == orig_comment_count+2
+
+    @pytest.mark.parametrize('video_data', [test_video_data[0]])
+    def test_nonvisible_comment_detection(self, astro_db, comment_dataframe, video_data):
+        conn = astro_db.get_db_conn()
+        cursor = conn.cursor()
+
+        # insert dataframe
+        astro_db.insert_comment_dataframe(video_data, comment_dataframe)
+
+        # get newly created comment table
+        comment_table = self.__get_comment_table_for_video_data(conn, video_data)
+        assert comment_table
+
+        # insert same dataframe, but with last row dropped
+        dropped_comment_id = comment_dataframe.loc[len(comment_dataframe.index)-1]['comment_id']
+        comment_dataframe.drop(len(comment_dataframe.index)-1, inplace=True)
+        astro_db.insert_comment_dataframe(video_data, comment_dataframe)
+
+        # verify that the comment's visibility was changed in the table
+        cursor.execute(f"SELECT comment_id FROM {comment_table} WHERE visible=FALSE")
+        comment_id = cursor.fetchone()[0]
+
+        assert comment_id == dropped_comment_id
+
+    @pytest.mark.parametrize('video_data', test_video_data)
+    def test_update_video_data(self, astro_db, comment_dataframe, video_data):
+        conn = astro_db.get_db_conn()
+        cursor = conn.cursor()
+
+        if not self.__insert_dataframe_exception(astro_db, comment_dataframe, video_data):
+            # insert comment dataframe to force Video table entry creation
+            astro_db.insert_comment_dataframe(video_data, comment_dataframe)
+
+            video_data.view_count = 1235813
+            video_data.like_count = 1111111
+            video_data.comment_count = 2222222
+            video_data.filtered_comment_count = 3333333
+
+            astro_db.update_video_data(video_data)
+
+            cursor.execute(f"SELECT * FROM Videos WHERE video_id='{video_data.video_id}'")
+            db_entry = cursor.fetchone()
+
+            assert db_entry[4] == video_data.view_count
+            assert db_entry[5] == video_data.like_count
+            assert db_entry[6] == video_data.comment_count
+            assert db_entry[7] == video_data.filtered_comment_count

--- a/src/tests/test_yt_data_api.py
+++ b/src/tests/test_yt_data_api.py
@@ -157,7 +157,7 @@ class TestYouTubeDataAPI:
                 viewCount=viewCount,
                 commentCount=commentCount)
 
-        video_data = youtube.get_video_metadata('video_id')
+        video_data = youtube.get_video_metadata('youtube.com/test/v=videoid')
 
         assert video_data.channel_id == channelId
         assert video_data.channel_title == channelTitle

--- a/src/tests/test_yt_data_api.py
+++ b/src/tests/test_yt_data_api.py
@@ -15,10 +15,14 @@ def parametrize_api_comment_response(
         publishedAt='',
         authorDisplayName='',
         replyTextDisplay='',
-        replyAuthorDisplayName=''):
+        replyAuthorDisplayName='',
+        commentID=''):
 
     if videoId:
         json_response['items'][0]['snippet']['videoId'] = videoId
+
+    if commentID:
+        json_response['items'][0]['id'] = commentID
 
     if textDisplay:
         json_response['items'][0]['snippet']['topLevelComment']['snippet']['textDisplay'] = textDisplay
@@ -70,6 +74,10 @@ class TestYouTubeDataAPI:
     @pytest.mark.parametrize('authorDisplayName', ['@test_user1', '@user-1234', '@best.youtuber'])
     @pytest.mark.parametrize('replyTextDisplay', ['reply text', 'hello 12345', 'test/reply'])
     @pytest.mark.parametrize('replyAuthorDisplayName', ['@test_replier1', '@test-replier1234', '@best.replier'])
+    @pytest.mark.parametrize('commentID',
+                             ['UgyMLcxXS1Id2SaBuJd4AaABAg',
+                              'UgwJuUmFZtOgkjrCrlp4AaABAg',
+                              'UgwJuUmFZtOgkjrCrlp4AaABAg.A9Y4JkqJXpPA9Y4Z0_I_BA'])
     def test_get_comments(
             self,
             logger,
@@ -79,7 +87,8 @@ class TestYouTubeDataAPI:
             publishedAt,
             authorDisplayName,
             replyTextDisplay,
-            replyAuthorDisplayName):
+            replyAuthorDisplayName,
+            commentID):
 
         youtube = YouTubeDataAPI(logger, 'test_apikey')
 
@@ -98,18 +107,20 @@ class TestYouTubeDataAPI:
             publishedAt=publishedAt,
             authorDisplayName=authorDisplayName,
             replyTextDisplay=replyTextDisplay,
-            replyAuthorDisplayName=replyAuthorDisplayName)
+            replyAuthorDisplayName=replyAuthorDisplayName,
+            commentID=commentID)
 
         df = youtube.get_comments(video_data)
 
         assert not df.empty
 
         """
-        The test data will only generate 2 rows in the dataframe:
+        The test data will only create 2 rows in the dataframe:
         one for the parent comment and one for the reply.
         """
         for index, row in df.iterrows():
             if index == 0:  # parent comment
+                assert commentID == row['comment_id']
                 assert textDisplay == row['comment']
                 assert publishedAt == row['date']
                 assert authorDisplayName == row['user']


### PR DESCRIPTION
Since I can't rely on the `commentCount` returned by YouTube's Data API, I've decided to abandon it entirely. Astro will now pull all comment data on each run, regardless of what data is stored locally. This is the only way I can see guaranteeing that we don't miss any comments. See [here](https://gist.github.com/AustinCullar/5656df71d4869bd73443f075271f26e4) for more information on the inconsistencies with `commentCount`.

Astro will now detect new comments by examining the dataframe built from the YouTube API response. It will also now track visibility changes in comments using a new `visible` column in the database. This will track the case where we've started tracking a video and see that the API stops returning a comment we've previously stored.

The comment `id` field is now being tracked. This field uniquely identifies a comment, but it also (unexpectedly) indicates a parent-reply relationship. For example, if comment B with id `bbbb` is responding to comment A with id `aaaa`, the id's would look as follows:
- comment A id: `aaaa`
- comment B id: `aaaa.bbbb`

A reply comment can thus be identified by scanning its `id` field for a `.` token.

Tests have been added/modified to account for these changes as well.